### PR TITLE
Update pg dep. to 0.13.2 due to breaking changes

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -30,7 +30,7 @@ shards:
 
   pg:
     github: will/crystal-pg
-    version: 0.13.1
+    version: 0.13.2
 
   sentry:
     github: TechMagister/sentry


### PR DESCRIPTION
Shards.lock is now at 0.13.2, and the release needs to be updated for Homebrew.