### PR TITLE
changes for new macros

### DIFF
--- a/src/templates/app/README.md.ecr
+++ b/src/templates/app/README.md.ecr
@@ -24,7 +24,7 @@ crystal build src/<%= @name %>.cr
 ## Docker and Docker Compose
 
 This will start an instance of postgres, migrate the database, run the specs,
-and launch the site at http://localhost:80
+and launch the site at http://localhost:3000
 ```
 docker-compose up -d
 ```

--- a/src/templates/app/docker-compose.yml.ecr
+++ b/src/templates/app/docker-compose.yml.ecr
@@ -67,7 +67,7 @@ services:
       - db
 
   db:
-    image: mysql
+    image: mysql:5.6
     ports:
       - "3306:3306"
     environment:

--- a/src/templates/app/shard.yml.ecr
+++ b/src/templates/app/shard.yml.ecr
@@ -9,7 +9,7 @@ license: MIT
 dependencies:
   kemalyst:
     github: drujensen/kemalyst
-    version: ~> 0.4.0
+    version: ~> 0.5.0
 <% case @database when "pg" %>
   pg:
     github: will/crystal-pg

--- a/src/templates/app/src/controllers/static_controller.cr.ecr
+++ b/src/templates/app/src/controllers/static_controller.cr.ecr
@@ -1,7 +1,7 @@
 module StaticController
   class Index < Kemalyst::Controller
     def call(context)
-    render "static/index.<%= @language %>", "main.<%= @language %>"
+      render "static/index.<%= @language %>", "main.<%= @language %>"
     end
   end
 end

--- a/src/templates/field.cr
+++ b/src/templates/field.cr
@@ -2,15 +2,9 @@ module Kemalyst::Generator
   class Field
     TYPE_MAPPING = {
       mysql: {
-        TEXT: "TEXT",
-        INT: "INT",
-        FLOAT: "FLOAT",
-        REAL: "REAL",
-        BOOL: "BOOL",
-        DATE: "DATE",
         TIMESTAMP: "TIMESTAMP NULL",
         VARCHAR: "VARCHAR(255)"
-      } 
+      }
     }
 
     property name : String

--- a/src/templates/model.cr
+++ b/src/templates/model.cr
@@ -9,17 +9,35 @@ module Kemalyst::Generator
     @fields : Array(Field)
     @database: String
     @timestamp: String
+    @primary_key : String
 
     def initialize(@name, fields)
-      @fields = fields.map {|field| Field.new(field)}
       @database = database
+      @fields = fields.map {|field| Field.new(field, database: @database)}
+      @fields += %w(created_at:time updated_at:time).map do |f|
+        Field.new(f, hidden: true)
+      end
       @timestamp = Time.now.to_s("%Y%m%d%H%M%S")
+      @primary_key = primary_key
     end
 
     def database
       yaml_file = File.read("config/database.yml")
       yaml = YAML.parse(yaml_file)
       yaml.first.to_s
+    end
+
+    def primary_key
+      case @database
+      when "pg"
+        "id BIGSERIAL PRIMARY KEY"
+      when "mysql"
+        "id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
+      when "sqlite"
+        "id INTEGER NOT NULL PRIMARY KEY"
+      else
+        "id INTEGER NOT NULL PRIMARY KEY"
+      end
     end
   end
 end

--- a/src/templates/model.cr
+++ b/src/templates/model.cr
@@ -15,7 +15,7 @@ module Kemalyst::Generator
       @database = database
       @fields = fields.map {|field| Field.new(field, database: @database)}
       @fields += %w(created_at:time updated_at:time).map do |f|
-        Field.new(f, hidden: true)
+        Field.new(f, hidden: true, database: @database)
       end
       @timestamp = Time.now.to_s("%Y%m%d%H%M%S")
       @primary_key = primary_key

--- a/src/templates/model/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/templates/model/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -1,35 +1,8 @@
 -- +micrate Up
-<% case @database
-   when "mysql" -%>
 CREATE TABLE <%= @name %>s (
-  id BIGINT NOT NULL AUTO_INCREMENT, 
-<% @fields.each do |field| -%>
-  <%= field.name %> <%= field.db_type %>,
-<% end -%>
-  created_at TIMESTAMP,
-  updated_at TIMESTAMP,
-  PRIMARY KEY (id)
-)
-<% when "pg" -%>
-CREATE TABLE <%= @name %>s (
-  id BIGSERIAL PRIMARY KEY,
-<% @fields.each do |field| -%>
-  <%= field.name %> <%= field.db_type %>,
-<% end -%>
-  created_at TIMESTAMP,
-  updated_at TIMESTAMP
-)
-<% else -%>
-CREATE TABLE <%= @name %>s (
-  id INTEGER NOT NULL PRIMARY KEY,
-<% @fields.each do |field| -%>
-  <%= field.name %> <%= field.db_type %>,
-<% end -%>
-  created_at VARCHAR,
-  updated_at VARCHAR
-)
-<% end -%>
+  <%= @primary_key %>,
+  <%= @fields.map{ |field| "#{field.name} #{field.db_mapped_type}" }.join(",\n  ") %>
+);
 
 -- +micrate Down
 DROP TABLE IF EXISTS <%= @name %>s;
-

--- a/src/templates/model/src/models/{{name}}.cr.ecr
+++ b/src/templates/model/src/models/{{name}}.cr.ecr
@@ -3,11 +3,11 @@ require "kemalyst-model/adapter/<%= @database %>"
 class <%= @name.capitalize %> < Kemalyst::Model
   adapter <%= @database %>
 
-  # id, created_at and updated_at columns are automatically created for you.
-  sql_mapping({
-<% @fields.each do |field| -%>
-    <%= field.name %>: <%= field.cr_type %>,
+  # id : Int64 primary key is created for you
+<% @fields.reject{|f| f.hidden }.each do |field| -%>
+  field <%= field.name %> : <%= field.cr_type %>
 <% end -%>
-  })
-
+<% if @database != "sqlite" -%>
+  timestamps
+<% end -%>
 end

--- a/src/templates/scaffold/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
+++ b/src/templates/scaffold/db/migrations/{{timestamp}}_create_{{name}}.sql.ecr
@@ -6,4 +6,3 @@ CREATE TABLE <%= @name %>s (
 
 -- +micrate Down
 DROP TABLE IF EXISTS <%= @name %>s;
-

--- a/src/templates/scaffold/src/models/{{name}}.cr.ecr
+++ b/src/templates/scaffold/src/models/{{name}}.cr.ecr
@@ -3,15 +3,11 @@ require "kemalyst-model/adapter/<%= @database %>"
 class <%= @name.capitalize %> < Kemalyst::Model
   adapter <%= @database %>
 
-  # id, created_at and updated_at columns are automatically created for you.
-  sql_mapping({
+  # id : Int64 primary key is created for you
 <% @fields.reject{|f| f.hidden }.each do |field| -%>
-    <%= field.name %>: <%= field.cr_type %>,
+  field <%= field.name %> : <%= field.cr_type %>
 <% end -%>
-<% if @database == "sqlite" -%>
-  }, nil, false)
-<% else -%>
-  })
+<% if @database != "sqlite" -%>
+  timestamps
 <% end -%>
-
 end


### PR DESCRIPTION
Move to leverage the `finished` macro in the models.  

This cleans up the ORMapping by using individual macros for specifying the table_name, field, and timestamps and then processing them with the `finished` callback macro.

Also changed to mysql:5.6 image which eliminates the errors generated by the mysql driver.
Finally, updated the model generator to match the scaffold one.