### PR TITLE
added link option to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ run:
 
 clean:
 	rm -rf  $(OUT_DIR) .crystal .shards libs lib
+
+link: 
+	@ln -s `pwd`/bin/kgen /usr/local/bin/kgen


### PR DESCRIPTION
`make link` will create simlink of ./bin/kgen to /usr/local/bin/kgen now.